### PR TITLE
feat: Add generateProjectKeypair() static method

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,27 +8,27 @@ Key management and encryption / decryption functions for Mapeo.
 
 ## Table of Contents
 
-  - [KeyManager](#keymanager)
-    - [Parameters](#parameters)
-    - [`km.getIdentityKeypair()`](#kmgetidentitykeypair)
-    - [`km.getIdentityBackupCode()`](#kmgetidentitybackupcode)
-    - [`km.getHypercoreKeypair(name, namespace)`](#kmgethypercorekeypairname-namespace)
-      - [Parameters](#parameters-1)
-    - [`km.getDerivedKey(name, namespace)`](#kmgetderivedkeyname-namespace)
-      - [Parameters](#parameters-2)
-    - [`KeyManager.generateRootKey()`](#keymanagergeneraterootkey)
-    - [`KeyManager.decodeBackupCode(backupCode)`](#keymanagerdecodebackupcodebackupcode)
-      - [Parameters](#parameters-3)
-  - [Project Invites](#project-invites)
-    - [`invites.encodeJoinRequest(joinRequest, options)`](#invitesencodejoinrequestjoinrequest-options)
-      - [Parameters](#parameters-4)
-    - [`invites.decodeJoinRequest(str, options)`](#invitesdecodejoinrequeststr-options)
-      - [Parameters](#parameters-5)
-    - [`invites.generateInvite(joinRequest, options)`](#invitesgenerateinvitejoinrequest-options)
-      - [Parameters](#parameters-6)
-    - [`invites.decodeInviteSecretMessage(invite, identityPublicKey, identitySecretKey, options)`](#invitesdecodeinvitesecretmessageinvite-identitypublickey-identitysecretkey-options)
-      - [Parameters](#parameters-7)
-  - [Type `JoinRequest`](#type-joinrequest)
+- [KeyManager](#keymanager)
+  - [Parameters](#parameters)
+  - [`km.getIdentityKeypair()`](#kmgetidentitykeypair)
+  - [`km.getIdentityBackupCode()`](#kmgetidentitybackupcode)
+  - [`km.getHypercoreKeypair(name, namespace)`](#kmgethypercorekeypairname-namespace)
+    - [Parameters](#parameters-1)
+  - [`km.getDerivedKey(name, namespace)`](#kmgetderivedkeyname-namespace)
+    - [Parameters](#parameters-2)
+  - [`KeyManager.generateRootKey()`](#keymanagergeneraterootkey)
+  - [`KeyManager.decodeBackupCode(backupCode)`](#keymanagerdecodebackupcodebackupcode)
+    - [Parameters](#parameters-3)
+- [Project Invites](#project-invites)
+  - [`invites.encodeJoinRequest(joinRequest, options)`](#invitesencodejoinrequestjoinrequest-options)
+    - [Parameters](#parameters-4)
+  - [`invites.decodeJoinRequest(str, options)`](#invitesdecodejoinrequeststr-options)
+    - [Parameters](#parameters-5)
+  - [`invites.generateInvite(joinRequest, options)`](#invitesgenerateinvitejoinrequest-options)
+    - [Parameters](#parameters-6)
+  - [`invites.decodeInviteSecretMessage(invite, identityPublicKey, identitySecretKey, options)`](#invitesdecodeinvitesecretmessageinvite-identitypublickey-identitysecretkey-options)
+    - [Parameters](#parameters-7)
+- [Type `JoinRequest`](#type-joinrequest)
 
 ## API
 
@@ -111,6 +111,14 @@ the CRC check fails.
 - `backupCode: string` 30-character base32 encoded backup code
 
 Returns `Buffer` The 16-byte root key encoded in the backup code
+
+#### `KeyManager.generateProjectKeypair()`
+
+Generate a keypair for a new project. The public key of this keypair becomes the project key. The keypair should be used as the keypair for the hypercore in the 'auth' namespace for the project creator.
+
+This keypair is non-deterministic, it must be persisted somewhere.
+
+Returns `{ publicKey: Buffer, secretKey: Buffer }`
 
 ### Project Invites
 

--- a/key-manager.js
+++ b/key-manager.js
@@ -119,6 +119,17 @@ class KeyManager {
   }
 
   /**
+   * Generate a keypair for a new project. The public key of this keypair
+   * becomes the project key. The keypair should be used as the keypair for the
+   * hypercore in the 'auth' namespace for the project creator.
+   *
+   * This keypair is non-deterministic, it must be persisted somewhere.
+   */
+  static generateProjectKeypair () {
+    return signKeypair()
+  }
+
+  /**
    * Decode the root key from a backup code. Throws an error if the CRC
    * check fails.
    *

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "sodium-universal": "^3.0.4"
   },
   "devDependencies": {
+    "@digidem/types": "^2.0.0",
     "@types/crc": "^3.4.0",
     "@types/lodash": "^4.14.178",
     "@types/node": "^17.0.0",
@@ -34,7 +35,9 @@
     "@types/tap": "^15.0.5",
     "@types/tape": "^4.13.2",
     "documentation": "^13.2.5",
+    "hypercore": "^10.18.5",
     "prettier": "^2.5.1",
+    "random-access-memory": "^6.2.0",
     "tap": "^15.1.5",
     "typescript": "^4.5.4"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,11 @@
     "emitDeclarationOnly": true,
     "declarationDir": "dist",
     "declarationMap": true,
-    "typeRoots": ["types", "node_modules/@types"]
+    "typeRoots": [
+      "types",
+      "node_modules/@types",
+      "node_modules/@digidem/types/vendor"
+    ]
   },
   "include": ["**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
`KeyManager.generateProjectKeypair()` can be used to generate a keypair
for a new Mapeo project. The public key of this keypair is the project
key. The keypair is used for the auth hypercore of the project creator.

Fixes #4