### PR TITLE
fix: add encrypt and decrypt methods to KeyManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,27 +8,29 @@ Key management and encryption / decryption functions for Mapeo.
 
 ## Table of Contents
 
-  - [KeyManager](#keymanager)
-    - [Parameters](#parameters)
-    - [`km.getIdentityKeypair()`](#kmgetidentitykeypair)
-    - [`km.getIdentityBackupCode()`](#kmgetidentitybackupcode)
-    - [`km.getHypercoreKeypair(name, namespace)`](#kmgethypercorekeypairname-namespace)
-      - [Parameters](#parameters-1)
-    - [`km.getDerivedKey(name, namespace)`](#kmgetderivedkeyname-namespace)
-      - [Parameters](#parameters-2)
-    - [`KeyManager.generateRootKey()`](#keymanagergeneraterootkey)
-    - [`KeyManager.decodeBackupCode(backupCode)`](#keymanagerdecodebackupcodebackupcode)
-      - [Parameters](#parameters-3)
-  - [Project Invites](#project-invites)
-    - [`invites.encodeJoinRequest(joinRequest, options)`](#invitesencodejoinrequestjoinrequest-options)
-      - [Parameters](#parameters-4)
-    - [`invites.decodeJoinRequest(str, options)`](#invitesdecodejoinrequeststr-options)
-      - [Parameters](#parameters-5)
-    - [`invites.generateInvite(joinRequest, options)`](#invitesgenerateinvitejoinrequest-options)
-      - [Parameters](#parameters-6)
-    - [`invites.decodeInviteSecretMessage(invite, identityPublicKey, identitySecretKey, options)`](#invitesdecodeinvitesecretmessageinvite-identitypublickey-identitysecretkey-options)
-      - [Parameters](#parameters-7)
-  - [Type `JoinRequest`](#type-joinrequest)
+- [KeyManager](#keymanager)
+  - [Parameters](#parameters)
+  - [`km.getIdentityKeypair()`](#kmgetidentitykeypair)
+  - [`km.getIdentityBackupCode()`](#kmgetidentitybackupcode)
+  - [`km.getHypercoreKeypair(name, namespace)`](#kmgethypercorekeypairname-namespace)
+    - [Parameters](#parameters-1)
+  - [`km.getDerivedKey(name, namespace)`](#kmgetderivedkeyname-namespace)
+    - [Parameters](#parameters-2)
+  - [`km.decryptLocalMessage(cypherText, projectId)`](#kmdecryptLocalMessagecypherText-projectId)
+  - [`km.encryptLocalMessage(msg, projectId)`](#kmencryptLocalMessagemsg-projectId)
+  - [`KeyManager.generateRootKey()`](#keymanagergeneraterootkey)
+  - [`KeyManager.decodeBackupCode(backupCode)`](#keymanagerdecodebackupcodebackupcode)
+    - [Parameters](#parameters-3)
+- [Project Invites](#project-invites)
+  - [`invites.encodeJoinRequest(joinRequest, options)`](#invitesencodejoinrequestjoinrequest-options)
+    - [Parameters](#parameters-4)
+  - [`invites.decodeJoinRequest(str, options)`](#invitesdecodejoinrequeststr-options)
+    - [Parameters](#parameters-5)
+  - [`invites.generateInvite(joinRequest, options)`](#invitesgenerateinvitejoinrequest-options)
+    - [Parameters](#parameters-6)
+  - [`invites.decodeInviteSecretMessage(invite, identityPublicKey, identitySecretKey, options)`](#invitesdecodeinvitesecretmessageinvite-identitypublickey-identitysecretkey-options)
+    - [Parameters](#parameters-7)
+- [Type `JoinRequest`](#type-joinrequest)
 
 ## API
 
@@ -91,6 +93,27 @@ generated for the same name if the identity key is the same.
 - `namespace: Buffer` 32-byte namespace
 
 Returns 32-byte `Buffer`
+
+#### `km.decryptLocalMessage(cypherText, projectId)`
+
+Decrypt an encrypted message (uses the first 24 bytes of the projectId as a nonce)
+
+##### Parameters
+
+- `cyphertext: Buffer` Encrypted message to decrypt
+- `projectId: string` projectId - 32-byte hex-encoded string
+
+#### `km.encryptLocalMessage(msg, projectId)`
+
+Encrypt a message (uses the first 24 bytes of the projectId as a nonce)
+This should only be used for encrypting local messages, not for sending
+messages over the internet, because the nonce is non-random, so messages
+could be subject to replay attacks.
+
+##### Parameters
+
+- `msg: Buffer` Message to encrypt
+- `projectId` projectId - 32-byte hex-encoded string
 
 #### `KeyManager.generateRootKey()`
 

--- a/key-manager.js
+++ b/key-manager.js
@@ -89,6 +89,53 @@ class KeyManager {
   }
 
   /**
+   * Decrypt an encrypted message (uses the first 24 bytes of the projectId as a nonce)
+   *
+   * @param {Buffer} cyphertext
+   * @param {string} projectId
+   */
+  decryptLocalMessage (cyphertext, projectId) {
+    const nonce = nonceFromProjectId(projectId)
+    const msg = Buffer.alloc(
+      cyphertext.length - sodium.crypto_aead_xchacha20poly1305_ietf_ABYTES
+    )
+    sodium.crypto_aead_xchacha20poly1305_ietf_decrypt(
+      msg,
+      null,
+      cyphertext,
+      null,
+      nonce,
+      this._masterKey
+    )
+    return msg
+  }
+
+  /**
+   * Encrypt a message (uses the first 24 bytes of the projectId as a nonce)
+   * This should only be used for encrypting local messages, not for sending
+   * messages over the internet, because the nonce is non-random, so messages
+   * could be subject to replay attacks
+   *
+   * @param {Buffer} msg
+   * @param {string} projectId
+   */
+  encryptLocalMessage (msg, projectId) {
+    const nonce = nonceFromProjectId(projectId)
+    const cyphertext = Buffer.alloc(
+      msg.length + sodium.crypto_aead_xchacha20poly1305_ietf_ABYTES
+    )
+    sodium.crypto_aead_xchacha20poly1305_ietf_encrypt(
+      cyphertext,
+      msg,
+      null,
+      null,
+      nonce,
+      this._masterKey
+    )
+    return cyphertext
+  }
+
+  /**
    * Generate a derived keypair for the given name. Deterministic: the same
    * keypair will be generated for the same name if the identity key is the
    * same.
@@ -163,3 +210,11 @@ class KeyManager {
 }
 
 module.exports = KeyManager
+
+/** @param {string} projectId */
+function nonceFromProjectId (projectId) {
+  return Buffer.from(projectId, 'hex').subarray(
+    0,
+    sodium.crypto_aead_xchacha20poly1305_ietf_NPUBBYTES
+  )
+}

--- a/tests/key-manager.test.js
+++ b/tests/key-manager.test.js
@@ -2,6 +2,7 @@
 const { test } = require('tap')
 const KeyManager = require('../key-manager')
 const { validateSignKeypair } = require('../lib/key-utils')
+const { randomBytes } = require('crypto')
 
 test('encoding backup code', t => {
   const rootKey = KeyManager.generateRootKey()
@@ -87,5 +88,23 @@ test('deterministic getDerivedKey', t => {
     km1.getDerivedKey('foo', namespace),
     km2.getDerivedKey('foo', namespace)
   )
+  t.end()
+})
+
+test('encrypt and decrypt', t => {
+  const message = Buffer.from('hello world')
+  const rootKey = KeyManager.generateRootKey()
+  const projectId = randomBytes(32).toString('hex')
+  const km = new KeyManager(rootKey)
+
+  const cypher = km.encryptLocalMessage(message, projectId)
+  // Not testing cryptographic security, but at least avoiding silly mistakes
+  t.notSame(
+    cypher,
+    message,
+    'encrypted data is not the same as original message'
+  )
+  const decrypted = km.decryptLocalMessage(cypher, projectId)
+  t.same(decrypted, message, 'message correctly decrypted')
   t.end()
 })


### PR DESCRIPTION
Fixes #3 

Uses the master key (derived from the root key) as an encryption key.
The project id is used as a nonce, so not secure for sending messages
subject to replay attacks, but should be "good enough" for local storage