### PR TITLE
feat: add sign & verify functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,20 +16,27 @@ Key management and encryption / decryption functions for Mapeo.
     - [Parameters](#parameters-1)
   - [`km.getDerivedKey(name, namespace)`](#kmgetderivedkeyname-namespace)
     - [Parameters](#parameters-2)
-  - [`km.decryptLocalMessage(cypherText, projectId)`](#kmdecryptLocalMessagecypherText-projectId)
-  - [`km.encryptLocalMessage(msg, projectId)`](#kmencryptLocalMessagemsg-projectId)
+  - [`km.decryptLocalMessage(cypherText, projectId)`](#kmdecryptlocalmessagecyphertext-projectid)
+    - [Parameters](#parameters-3)
+  - [`km.encryptLocalMessage(msg, projectId)`](#kmencryptlocalmessagemsg-projectid)
+    - [Parameters](#parameters-4)
   - [`KeyManager.generateRootKey()`](#keymanagergeneraterootkey)
   - [`KeyManager.decodeBackupCode(backupCode)`](#keymanagerdecodebackupcodebackupcode)
-    - [Parameters](#parameters-3)
+    - [Parameters](#parameters-5)
+  - [`KeyManager.generateProjectKeypair()`](#keymanagergenerateprojectkeypair)
 - [Project Invites](#project-invites)
   - [`invites.encodeJoinRequest(joinRequest, options)`](#invitesencodejoinrequestjoinrequest-options)
-    - [Parameters](#parameters-4)
-  - [`invites.decodeJoinRequest(str, options)`](#invitesdecodejoinrequeststr-options)
-    - [Parameters](#parameters-5)
-  - [`invites.generateInvite(joinRequest, options)`](#invitesgenerateinvitejoinrequest-options)
     - [Parameters](#parameters-6)
-  - [`invites.decodeInviteSecretMessage(invite, identityPublicKey, identitySecretKey, options)`](#invitesdecodeinvitesecretmessageinvite-identitypublickey-identitysecretkey-options)
+  - [`invites.decodeJoinRequest(str, options)`](#invitesdecodejoinrequeststr-options)
     - [Parameters](#parameters-7)
+  - [`invites.generateInvite(joinRequest, options)`](#invitesgenerateinvitejoinrequest-options)
+    - [Parameters](#parameters-8)
+  - [`invites.decodeInviteSecretMessage(invite, identityPublicKey, identitySecretKey, options)`](#invitesdecodeinvitesecretmessageinvite-identitypublickey-identitysecretkey-options)
+    - [Parameters](#parameters-9)
+- [`sign(message, secretKey)`](#signmessage-secretkey)
+  - [Parameters](#parameters-10)
+- [`verify(message, signature, publicKey)`](#verifymessage-signature-publickey)
+  - [Parameters](#parameters-11)
 - [Type `JoinRequest`](#type-joinrequest)
 
 ## API
@@ -225,6 +232,29 @@ decrypted message includes the project key for the project the invite is for.
   - `options.encoding: 'base32' | 'base62'` Use base32 if using for an alphanumeric encoded QR Code (uppercase A-Z, 0-9), or base62 for a URL.
 
 Returns `{ projectKey: Buffer, encryptionKey?: Buffer }` Decrypted secret project key and optional encryption key.
+
+### `sign(message, secretKey)`
+
+Sign `message` using `secretKey`
+
+#### Parameters
+
+- `message: Buffer`
+- `secretKey: Buffer`
+
+Returns `Buffer` signature of the message
+
+### `verify(message, signature, publicKey)`
+
+Verify that `signature` is a valid signature of `message` created by the owner of `publicKey`.
+
+#### Parameters
+
+- `message: Buffer`
+- `signature: Buffer`
+- `publicKey: Buffer`
+
+Returns `boolean` indicating if valid or not.
 
 ### Type `JoinRequest`
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,7 @@
+// @ts-check
+
 module.exports = {
   KeyManager: require('./key-manager'),
   invites: require('./project-invites'),
+  ...require('./utils.js')
 }

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,0 +1,17 @@
+// @ts-check
+const { test } = require('tap')
+const { randomBytes } = require('node:crypto')
+const { KeyManager, sign, verify } = require('../')
+
+test('sign & verify', function (t) {
+  const km = new KeyManager(randomBytes(16))
+  const keyPair = km.getIdentityKeypair()
+  const message = Buffer.from('hello world')
+
+  const sig = sign(message, keyPair.secretKey)
+
+  t.equal(sig.length, 64)
+  t.ok(verify(message, sig, keyPair.publicKey))
+  t.notOk(verify(message, Buffer.alloc(64), keyPair.publicKey))
+  t.end()
+})

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 const { test } = require('tap')
-const { randomBytes } = require('node:crypto')
+const { randomBytes } = require('crypto')
 const { KeyManager, sign, verify } = require('../')
 
 test('sign & verify', function (t) {

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,7 +1,7 @@
 // @ts-check
 const { test } = require('tap')
 const { randomBytes } = require('crypto')
-const { KeyManager, sign, verify } = require('../')
+const { KeyManager, sign, verifySignature } = require('../')
 
 test('sign & verify', function (t) {
   const km = new KeyManager(randomBytes(16))
@@ -11,7 +11,7 @@ test('sign & verify', function (t) {
   const sig = sign(message, keyPair.secretKey)
 
   t.equal(sig.length, 64)
-  t.ok(verify(message, sig, keyPair.publicKey))
-  t.notOk(verify(message, Buffer.alloc(64), keyPair.publicKey))
+  t.ok(verifySignature(message, sig, keyPair.publicKey))
+  t.notOk(verifySignature(message, Buffer.alloc(64), keyPair.publicKey))
   t.end()
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,6 @@
       "node_modules/@digidem/types/vendor"
     ]
   },
-  "include": ["**/*"],
+  "include": ["index.js"],
   "exclude": ["node_modules", "dist"]
 }

--- a/utils.js
+++ b/utils.js
@@ -21,6 +21,6 @@ exports.sign = function (message, secretKey) {
  * @param {Buffer} publicKey public key of keypair used to sign message
  * @returns {boolean}
  */
-exports.verify = function (message, signature, publicKey) {
+exports.verifySignature = function (message, signature, publicKey) {
   return sodium.crypto_sign_verify_detached(signature, message, publicKey)
 }

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,26 @@
+// @ts-check
+const sodium = require('sodium-universal')
+
+/**
+ * Sign message using secretKey
+ *
+ * @param {Buffer} message
+ * @param {Buffer} secretKey
+ */
+exports.sign = function (message, secretKey) {
+  const signature = Buffer.allocUnsafe(sodium.crypto_sign_BYTES)
+  sodium.crypto_sign_detached(signature, message, secretKey)
+  return signature
+}
+
+/**
+ * Verify if the message signature is valid
+ *
+ * @param {Buffer} message
+ * @param {Buffer} signature
+ * @param {Buffer} publicKey public key of keypair used to sign message
+ * @returns {boolean}
+ */
+exports.verify = function (message, signature, publicKey) {
+  return sodium.crypto_sign_verify_detached(signature, message, publicKey)
+}


### PR DESCRIPTION
Fixes #11

Note: The change to `tsconfig.json` is necessary because `test/utils.test.js` imports `index.js`. Because `package.json` `types` field points to `dist/index.d.ts`, TS resolves the import of `index.js` to `dist/index.d.ts`. This means that despite `dist` being in the `exclude` option of `tsconfig`, it is still included due to the reference from the test. The fix is to only include `index.js` and only follow the imports from there. Yeah... that's more confusing now it's written down... but the fix works. 