### PR TITLE
fix: support named ESM named exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 // @ts-check
+const { sign, verifySignature, projectKeyToPublicId } = require('./utils.js')
 
-module.exports = {
-  KeyManager: require('./key-manager'),
-  invites: require('./project-invites'),
-  ...require('./utils.js')
-}
+exports.KeyManager = require('./key-manager')
+exports.invites = require('./project-invites')
+exports.sign = sign
+exports.verifySignature = verifySignature
+exports.projectKeyToPublicId = projectKeyToPublicId


### PR DESCRIPTION
For the "why" see https://2ality.com/2022/10/commonjs-named-exports.html

Tested locally via `npm pack` then install in a temp module, and it works for me.

Fixes #15