### PR TITLE
fix: update encryptLocalMessage and decryptLocalMessage methods to accept nonce instead of project ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Decrypt an encrypted message using the provided nonce parameter
 ##### Parameters
 
 - `cyphertext: Buffer` Encrypted message to decrypt
-- `nonce: Buffer` Buffer of length sodium.crypto_aead_xchacha20poly1305_ietf_NPUBBYTES bytes
+- `nonce: Buffer` 24-byte nonce
 
 #### `km.encryptLocalMessage(msg, nonce)`
 
@@ -122,7 +122,7 @@ could be subject to replay attacks.
 ##### Parameters
 
 - `msg: Buffer` Message to encrypt
-- `nonce: Buffer` Buffer of length sodium.crypto_aead_xchacha20poly1305_ietf_NPUBBYTES bytes
+- `nonce: Buffer` 24-byte nonce
 
 #### `KeyManager.generateRootKey()`
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Key management and encryption / decryption functions for Mapeo.
     - [Parameters](#parameters-1)
   - [`km.getDerivedKey(name, namespace)`](#kmgetderivedkeyname-namespace)
     - [Parameters](#parameters-2)
-  - [`km.decryptLocalMessage(cypherText, projectId)`](#kmdecryptlocalmessagecyphertext-projectid)
+  - [`km.decryptLocalMessage(cypherText, nonce)`](#kmdecryptlocalmessagecyphertext-projectid)
     - [Parameters](#parameters-3)
-  - [`km.encryptLocalMessage(msg, projectId)`](#kmencryptlocalmessagemsg-projectid)
+  - [`km.encryptLocalMessage(msg, nonce)`](#kmencryptlocalmessagemsg-projectid)
     - [Parameters](#parameters-4)
   - [`KeyManager.generateRootKey()`](#keymanagergeneraterootkey)
   - [`KeyManager.decodeBackupCode(backupCode)`](#keymanagerdecodebackupcodebackupcode)
@@ -105,16 +105,16 @@ Returns 32-byte `Buffer`
 
 #### `km.decryptLocalMessage(cypherText, projectId)`
 
-Decrypt an encrypted message (uses the first 24 bytes of the projectId as a nonce)
+Decrypt an encrypted message using the provided nonce parameter
 
 ##### Parameters
 
 - `cyphertext: Buffer` Encrypted message to decrypt
-- `projectId: string` projectId - 32-byte hex-encoded string
+- `nonce: Buffer` Buffer of length sodium.crypto_aead_xchacha20poly1305_ietf_NPUBBYTES bytes
 
-#### `km.encryptLocalMessage(msg, projectId)`
+#### `km.encryptLocalMessage(msg, nonce)`
 
-Encrypt a message (uses the first 24 bytes of the projectId as a nonce)
+Encrypt a message using the provided nonce parameter
 This should only be used for encrypting local messages, not for sending
 messages over the internet, because the nonce is non-random, so messages
 could be subject to replay attacks.
@@ -122,7 +122,7 @@ could be subject to replay attacks.
 ##### Parameters
 
 - `msg: Buffer` Message to encrypt
-- `projectId` projectId - 32-byte hex-encoded string
+- `nonce: Buffer` Buffer of length sodium.crypto_aead_xchacha20poly1305_ietf_NPUBBYTES bytes
 
 #### `KeyManager.generateRootKey()`
 

--- a/key-manager.js
+++ b/key-manager.js
@@ -90,13 +90,12 @@ class KeyManager {
   }
 
   /**
-   * Decrypt an encrypted message (uses the first 24 bytes of the projectId as a nonce)
+   * Decrypt an encrypted message using the provided nonce parameter
    *
    * @param {Buffer} cyphertext
-   * @param {string} projectId
+   * @param {Buffer} nonce Buffer of length sodium.crypto_aead_xchacha20poly1305_ietf_NPUBBYTES bytes
    */
-  decryptLocalMessage(cyphertext, projectId) {
-    const nonce = nonceFromProjectId(projectId)
+  decryptLocalMessage(cyphertext, nonce) {
     const msg = Buffer.alloc(
       cyphertext.length - sodium.crypto_aead_xchacha20poly1305_ietf_ABYTES
     )
@@ -112,16 +111,15 @@ class KeyManager {
   }
 
   /**
-   * Encrypt a message (uses the first 24 bytes of the projectId as a nonce)
+   * Encrypt a message using the provided nonce parameter
    * This should only be used for encrypting local messages, not for sending
    * messages over the internet, because the nonce is non-random, so messages
    * could be subject to replay attacks
    *
    * @param {Buffer} msg
-   * @param {string} projectId
+   * @param {Buffer} nonce Buffer of length sodium.crypto_aead_xchacha20poly1305_ietf_NPUBBYTES bytes
    */
-  encryptLocalMessage(msg, projectId) {
-    const nonce = nonceFromProjectId(projectId)
+  encryptLocalMessage(msg, nonce) {
     const cyphertext = Buffer.alloc(
       msg.length + sodium.crypto_aead_xchacha20poly1305_ietf_ABYTES
     )
@@ -222,13 +220,3 @@ class KeyManager {
 }
 
 module.exports = KeyManager
-
-/** @param {string} projectId z-base-32 encoded hash of the project key */
-function nonceFromProjectId(projectId) {
-  const decoded = z32.decode(projectId)
-  return Buffer.from(
-    decoded.buffer,
-    decoded.byteOffset,
-    decoded.byteLength
-  ).subarray(0, sodium.crypto_aead_xchacha20poly1305_ietf_NPUBBYTES)
-}

--- a/key-manager.js
+++ b/key-manager.js
@@ -5,7 +5,7 @@ const z32 = require('z32')
 const {
   deriveMasterKeyFromRootKey,
   deriveNamedKey,
-  signKeypair,
+  signKeypair
 } = require('./lib/key-utils')
 const StringEncoding = require('./lib/string-encoding')
 const ByteEncoding = require('./lib/byte-encoding')
@@ -33,7 +33,7 @@ class KeyManager {
   /**
    * @param {Buffer} rootKey 16-bytes of random data that uniquely identify the device, used to derive a 32-byte master key, which is used to derive all the keypairs used for Mapeo
    */
-  constructor(rootKey) {
+  constructor (rootKey) {
     assert(
       rootKey.length === ROOTKEY_BYTES,
       `rootKey must be ${ROOTKEY_BYTES} bytes`
@@ -48,15 +48,15 @@ class KeyManager {
    *
    * @returns {Keypair}
    */
-  getIdentityKeypair() {
+  getIdentityKeypair () {
     return this._signingKeypair('identity')
   }
 
-  getIdentityBackupCode() {
+  getIdentityBackupCode () {
     const crc16 = calculateCrc16(this._rootKey)
     const encodedBackupCode = ByteEncoding.backupCode.encode({
       rootKey: this._rootKey,
-      crc16,
+      crc16
     })
     return (
       BACKUP_CODE_IDENTIFIER + StringEncoding.base32.encode(encodedBackupCode)
@@ -71,7 +71,7 @@ class KeyManager {
    * @param {Buffer} namespace 32-byte namespace
    * @returns {Keypair}
    */
-  getHypercoreKeypair(name, namespace) {
+  getHypercoreKeypair (name, namespace) {
     // TODO: For hypercore-next return a sign function
     return this._signingKeypair(name, namespace)
   }
@@ -85,7 +85,7 @@ class KeyManager {
    * @param {Buffer} [token] Optional 32-byte token to use for key derivation, e.g. to namespace keys.
    * @returns {Buffer} 32-byte buffer
    */
-  getDerivedKey(name, token) {
+  getDerivedKey (name, token) {
     return deriveNamedKey(this._masterKey, name, token)
   }
 
@@ -95,7 +95,7 @@ class KeyManager {
    * @param {Buffer} cyphertext
    * @param {Buffer} nonce Buffer of length sodium.crypto_aead_xchacha20poly1305_ietf_NPUBBYTES bytes
    */
-  decryptLocalMessage(cyphertext, nonce) {
+  decryptLocalMessage (cyphertext, nonce) {
     const msg = Buffer.alloc(
       cyphertext.length - sodium.crypto_aead_xchacha20poly1305_ietf_ABYTES
     )
@@ -119,7 +119,7 @@ class KeyManager {
    * @param {Buffer} msg
    * @param {Buffer} nonce Buffer of length sodium.crypto_aead_xchacha20poly1305_ietf_NPUBBYTES bytes
    */
-  encryptLocalMessage(msg, nonce) {
+  encryptLocalMessage (msg, nonce) {
     const cyphertext = Buffer.alloc(
       msg.length + sodium.crypto_aead_xchacha20poly1305_ietf_ABYTES
     )
@@ -144,7 +144,7 @@ class KeyManager {
    * @param {Buffer} [token] Optional 32-byte token to use for key derivation, e.g. to namespace keys.
    * @returns {Keypair}
    */
-  _signingKeypair(name, token) {
+  _signingKeypair (name, token) {
     // TODO: Cache / memoize keypair generation? Is this expensive?
     const seed = this.getDerivedKey(name, token)
     return signKeypair(seed)
@@ -158,7 +158,7 @@ class KeyManager {
    *
    * @returns {Buffer}
    */
-  static generateRootKey() {
+  static generateRootKey () {
     const buf = sodium.sodium_malloc(ROOTKEY_BYTES)
     sodium.randombytes_buf(buf)
     return buf
@@ -171,7 +171,7 @@ class KeyManager {
    *
    * This keypair is non-deterministic, it must be persisted somewhere.
    */
-  static generateProjectKeypair() {
+  static generateProjectKeypair () {
     return signKeypair()
   }
 
@@ -182,7 +182,7 @@ class KeyManager {
    * @param {string} stringEncodedBackupCode
    * @returns {Buffer} The 16-byte root key encoded in the backup code
    */
-  static decodeBackupCode(stringEncodedBackupCode) {
+  static decodeBackupCode (stringEncodedBackupCode) {
     assert(
       stringEncodedBackupCode.startsWith(BACKUP_CODE_IDENTIFIER),
       'Invalid backup code: must start with ' + BACKUP_CODE_IDENTIFIER

--- a/key-manager.js
+++ b/key-manager.js
@@ -5,7 +5,7 @@ const z32 = require('z32')
 const {
   deriveMasterKeyFromRootKey,
   deriveNamedKey,
-  signKeypair
+  signKeypair,
 } = require('./lib/key-utils')
 const StringEncoding = require('./lib/string-encoding')
 const ByteEncoding = require('./lib/byte-encoding')
@@ -33,7 +33,7 @@ class KeyManager {
   /**
    * @param {Buffer} rootKey 16-bytes of random data that uniquely identify the device, used to derive a 32-byte master key, which is used to derive all the keypairs used for Mapeo
    */
-  constructor (rootKey) {
+  constructor(rootKey) {
     assert(
       rootKey.length === ROOTKEY_BYTES,
       `rootKey must be ${ROOTKEY_BYTES} bytes`
@@ -48,15 +48,15 @@ class KeyManager {
    *
    * @returns {Keypair}
    */
-  getIdentityKeypair () {
+  getIdentityKeypair() {
     return this._signingKeypair('identity')
   }
 
-  getIdentityBackupCode () {
+  getIdentityBackupCode() {
     const crc16 = calculateCrc16(this._rootKey)
     const encodedBackupCode = ByteEncoding.backupCode.encode({
       rootKey: this._rootKey,
-      crc16
+      crc16,
     })
     return (
       BACKUP_CODE_IDENTIFIER + StringEncoding.base32.encode(encodedBackupCode)
@@ -71,7 +71,7 @@ class KeyManager {
    * @param {Buffer} namespace 32-byte namespace
    * @returns {Keypair}
    */
-  getHypercoreKeypair (name, namespace) {
+  getHypercoreKeypair(name, namespace) {
     // TODO: For hypercore-next return a sign function
     return this._signingKeypair(name, namespace)
   }
@@ -85,7 +85,7 @@ class KeyManager {
    * @param {Buffer} [token] Optional 32-byte token to use for key derivation, e.g. to namespace keys.
    * @returns {Buffer} 32-byte buffer
    */
-  getDerivedKey (name, token) {
+  getDerivedKey(name, token) {
     return deriveNamedKey(this._masterKey, name, token)
   }
 
@@ -95,7 +95,7 @@ class KeyManager {
    * @param {Buffer} cyphertext
    * @param {string} projectId
    */
-  decryptLocalMessage (cyphertext, projectId) {
+  decryptLocalMessage(cyphertext, projectId) {
     const nonce = nonceFromProjectId(projectId)
     const msg = Buffer.alloc(
       cyphertext.length - sodium.crypto_aead_xchacha20poly1305_ietf_ABYTES
@@ -120,7 +120,7 @@ class KeyManager {
    * @param {Buffer} msg
    * @param {string} projectId
    */
-  encryptLocalMessage (msg, projectId) {
+  encryptLocalMessage(msg, projectId) {
     const nonce = nonceFromProjectId(projectId)
     const cyphertext = Buffer.alloc(
       msg.length + sodium.crypto_aead_xchacha20poly1305_ietf_ABYTES
@@ -146,7 +146,7 @@ class KeyManager {
    * @param {Buffer} [token] Optional 32-byte token to use for key derivation, e.g. to namespace keys.
    * @returns {Keypair}
    */
-  _signingKeypair (name, token) {
+  _signingKeypair(name, token) {
     // TODO: Cache / memoize keypair generation? Is this expensive?
     const seed = this.getDerivedKey(name, token)
     return signKeypair(seed)
@@ -160,7 +160,7 @@ class KeyManager {
    *
    * @returns {Buffer}
    */
-  static generateRootKey () {
+  static generateRootKey() {
     const buf = sodium.sodium_malloc(ROOTKEY_BYTES)
     sodium.randombytes_buf(buf)
     return buf
@@ -173,7 +173,7 @@ class KeyManager {
    *
    * This keypair is non-deterministic, it must be persisted somewhere.
    */
-  static generateProjectKeypair () {
+  static generateProjectKeypair() {
     return signKeypair()
   }
 
@@ -184,7 +184,7 @@ class KeyManager {
    * @param {string} stringEncodedBackupCode
    * @returns {Buffer} The 16-byte root key encoded in the backup code
    */
-  static decodeBackupCode (stringEncodedBackupCode) {
+  static decodeBackupCode(stringEncodedBackupCode) {
     assert(
       stringEncodedBackupCode.startsWith(BACKUP_CODE_IDENTIFIER),
       'Invalid backup code: must start with ' + BACKUP_CODE_IDENTIFIER

--- a/key-manager.js
+++ b/key-manager.js
@@ -92,7 +92,7 @@ class KeyManager {
    * Decrypt an encrypted message using the provided nonce parameter
    *
    * @param {Buffer} cyphertext
-   * @param {Buffer} nonce Buffer of length sodium.crypto_aead_xchacha20poly1305_ietf_NPUBBYTES bytes
+   * @param {Buffer} nonce 24-byte nonce
    */
   decryptLocalMessage (cyphertext, nonce) {
     const msg = Buffer.alloc(
@@ -116,7 +116,7 @@ class KeyManager {
    * could be subject to replay attacks
    *
    * @param {Buffer} msg
-   * @param {Buffer} nonce Buffer of length sodium.crypto_aead_xchacha20poly1305_ietf_NPUBBYTES bytes
+   * @param {Buffer} nonce 24-byte nonce
    */
   encryptLocalMessage (msg, nonce) {
     const cyphertext = Buffer.alloc(

--- a/key-manager.js
+++ b/key-manager.js
@@ -1,6 +1,7 @@
 // @ts-check
 const sodium = require('sodium-native')
 const assert = require('assert')
+const z32 = require('z32')
 const {
   deriveMasterKeyFromRootKey,
   deriveNamedKey,
@@ -222,10 +223,12 @@ class KeyManager {
 
 module.exports = KeyManager
 
-/** @param {string} projectId */
-function nonceFromProjectId (projectId) {
-  return Buffer.from(projectId, 'hex').subarray(
-    0,
-    sodium.crypto_aead_xchacha20poly1305_ietf_NPUBBYTES
-  )
+/** @param {string} projectId z-base-32 encoded hash of the project key */
+function nonceFromProjectId(projectId) {
+  const decoded = z32.decode(projectId)
+  return Buffer.from(
+    decoded.buffer,
+    decoded.byteOffset,
+    decoded.byteLength
+  ).subarray(0, sodium.crypto_aead_xchacha20poly1305_ietf_NPUBBYTES)
 }

--- a/key-manager.js
+++ b/key-manager.js
@@ -1,7 +1,6 @@
 // @ts-check
 const sodium = require('sodium-native')
 const assert = require('assert')
-const z32 = require('z32')
 const {
   deriveMasterKeyFromRootKey,
   deriveNamedKey,

--- a/tests/key-manager.test.js
+++ b/tests/key-manager.test.js
@@ -8,7 +8,7 @@ const sodium = require('sodium-native')
 const z32 = require('z32')
 const { projectKeyToPublicId } = require('../utils')
 
-test('encoding backup code', (t) => {
+test('encoding backup code', t => {
   const rootKey = KeyManager.generateRootKey()
   const km = new KeyManager(rootKey)
   const backupCode = km.getIdentityBackupCode()
@@ -21,7 +21,7 @@ test('encoding backup code', (t) => {
   t.end()
 })
 
-test('decoding backup code', (t) => {
+test('decoding backup code', t => {
   const rootKey = KeyManager.generateRootKey()
   const km = new KeyManager(rootKey)
   const backupCode = km.getIdentityBackupCode()
@@ -30,7 +30,7 @@ test('decoding backup code', (t) => {
   t.end()
 })
 
-test('invalid backup codes', (t) => {
+test('invalid backup codes', t => {
   const rootKey = KeyManager.generateRootKey()
   const km = new KeyManager(rootKey)
   const validBackupCode = km.getIdentityBackupCode()
@@ -52,7 +52,7 @@ test('invalid backup codes', (t) => {
     // transcription error
     validBackupCode.slice(0, 5) +
       (validBackupCode.charAt(5) === 'W' ? 'V' : 'W') +
-      validBackupCode.slice(6),
+      validBackupCode.slice(6)
   ]
 
   for (const code of invalidBackupCodes) {
@@ -61,7 +61,7 @@ test('invalid backup codes', (t) => {
   t.end()
 })
 
-test('identity keypair', (t) => {
+test('identity keypair', t => {
   const rootKey = KeyManager.generateRootKey()
   const km1 = new KeyManager(rootKey)
   const km2 = new KeyManager(rootKey)
@@ -70,7 +70,7 @@ test('identity keypair', (t) => {
   t.end()
 })
 
-test('hypercore keypair', (t) => {
+test('hypercore keypair', t => {
   const rootKey = KeyManager.generateRootKey()
   const namespace = Buffer.alloc(32, 5)
   const km1 = new KeyManager(rootKey)
@@ -83,7 +83,7 @@ test('hypercore keypair', (t) => {
   t.end()
 })
 
-test('deterministic getDerivedKey', (t) => {
+test('deterministic getDerivedKey', t => {
   const rootKey = KeyManager.generateRootKey()
   const namespace = Buffer.alloc(32, 5)
   const km1 = new KeyManager(rootKey)
@@ -95,7 +95,7 @@ test('deterministic getDerivedKey', (t) => {
   t.end()
 })
 
-test('encrypt and decrypt', (t) => {
+test('encrypt and decrypt', t => {
   const message = Buffer.from('hello world')
   const rootKey = KeyManager.generateRootKey()
   const km = new KeyManager(rootKey)
@@ -115,7 +115,7 @@ test('encrypt and decrypt', (t) => {
   t.end()
 })
 
-test('projectKeypair can be used to create a hypercore', async (t) => {
+test('projectKeypair can be used to create a hypercore', async t => {
   /** @type {Record<string, RAM>} */
   const st = {}
   const keyPair = KeyManager.generateProjectKeypair()
@@ -136,14 +136,14 @@ test('projectKeypair can be used to create a hypercore', async (t) => {
   await reopen.close()
 
   /** @param {string} name */
-  function open(name) {
+  function open (name) {
     if (st[name]) return st[name]
     st[name] = new RAM()
     return st[name]
   }
 })
 
-test('projectKeypair is non-deterministic (always changes)', (t) => {
+test('projectKeypair is non-deterministic (always changes)', t => {
   // Not a strong test, but catches an error where we might pass a seed
   // internally so that the same keypair is always generated
   const keypair1 = KeyManager.generateProjectKeypair()

--- a/tests/key-manager.test.js
+++ b/tests/key-manager.test.js
@@ -4,8 +4,9 @@ const KeyManager = require('../key-manager')
 const { validateSignKeypair } = require('../lib/key-utils')
 const Hypercore = require('hypercore')
 const RAM = require('random-access-memory')
+const { projectKeyToPublicId } = require('../utils')
 
-test('encoding backup code', t => {
+test('encoding backup code', (t) => {
   const rootKey = KeyManager.generateRootKey()
   const km = new KeyManager(rootKey)
   const backupCode = km.getIdentityBackupCode()
@@ -18,7 +19,7 @@ test('encoding backup code', t => {
   t.end()
 })
 
-test('decoding backup code', t => {
+test('decoding backup code', (t) => {
   const rootKey = KeyManager.generateRootKey()
   const km = new KeyManager(rootKey)
   const backupCode = km.getIdentityBackupCode()
@@ -27,7 +28,7 @@ test('decoding backup code', t => {
   t.end()
 })
 
-test('invalid backup codes', t => {
+test('invalid backup codes', (t) => {
   const rootKey = KeyManager.generateRootKey()
   const km = new KeyManager(rootKey)
   const validBackupCode = km.getIdentityBackupCode()
@@ -49,7 +50,7 @@ test('invalid backup codes', t => {
     // transcription error
     validBackupCode.slice(0, 5) +
       (validBackupCode.charAt(5) === 'W' ? 'V' : 'W') +
-      validBackupCode.slice(6)
+      validBackupCode.slice(6),
   ]
 
   for (const code of invalidBackupCodes) {
@@ -58,7 +59,7 @@ test('invalid backup codes', t => {
   t.end()
 })
 
-test('identity keypair', t => {
+test('identity keypair', (t) => {
   const rootKey = KeyManager.generateRootKey()
   const km1 = new KeyManager(rootKey)
   const km2 = new KeyManager(rootKey)
@@ -67,7 +68,7 @@ test('identity keypair', t => {
   t.end()
 })
 
-test('hypercore keypair', t => {
+test('hypercore keypair', (t) => {
   const rootKey = KeyManager.generateRootKey()
   const namespace = Buffer.alloc(32, 5)
   const km1 = new KeyManager(rootKey)
@@ -80,7 +81,7 @@ test('hypercore keypair', t => {
   t.end()
 })
 
-test('deterministic getDerivedKey', t => {
+test('deterministic getDerivedKey', (t) => {
   const rootKey = KeyManager.generateRootKey()
   const namespace = Buffer.alloc(32, 5)
   const km1 = new KeyManager(rootKey)
@@ -92,7 +93,7 @@ test('deterministic getDerivedKey', t => {
   t.end()
 })
 
-test('encrypt and decrypt', t => {
+test('encrypt and decrypt', (t) => {
   const message = Buffer.from('hello world')
   const rootKey = KeyManager.generateRootKey()
   const km = new KeyManager(rootKey)
@@ -111,7 +112,7 @@ test('encrypt and decrypt', t => {
   t.end()
 })
 
-test('projectKeypair can be used to create a hypercore', async t => {
+test('projectKeypair can be used to create a hypercore', async (t) => {
   /** @type {Record<string, RAM>} */
   const st = {}
   const keyPair = KeyManager.generateProjectKeypair()
@@ -132,14 +133,14 @@ test('projectKeypair can be used to create a hypercore', async t => {
   await reopen.close()
 
   /** @param {string} name */
-  function open (name) {
+  function open(name) {
     if (st[name]) return st[name]
     st[name] = new RAM()
     return st[name]
   }
 })
 
-test('projectKeypair is non-deterministic (always changes)', t => {
+test('projectKeypair is non-deterministic (always changes)', (t) => {
   // Not a strong test, but catches an error where we might pass a seed
   // internally so that the same keypair is always generated
   const keypair1 = KeyManager.generateProjectKeypair()

--- a/tests/key-manager.test.js
+++ b/tests/key-manager.test.js
@@ -2,7 +2,6 @@
 const { test } = require('tap')
 const KeyManager = require('../key-manager')
 const { validateSignKeypair } = require('../lib/key-utils')
-const { randomBytes } = require('crypto')
 const Hypercore = require('hypercore')
 const RAM = require('random-access-memory')
 
@@ -96,8 +95,9 @@ test('deterministic getDerivedKey', t => {
 test('encrypt and decrypt', t => {
   const message = Buffer.from('hello world')
   const rootKey = KeyManager.generateRootKey()
-  const projectId = randomBytes(32).toString('hex')
   const km = new KeyManager(rootKey)
+  const projectKey = KeyManager.generateProjectKeypair().publicKey
+  const projectId = projectKeyToPublicId(projectKey)
 
   const cypher = km.encryptLocalMessage(message, projectId)
   // Not testing cryptographic security, but at least avoiding silly mistakes


### PR DESCRIPTION
Fixes #17 

~See https://github.com/digidem/mapeo-crypto/commit/40511a0e0698fdcfcda467ac89770097ee8c26c6 for changes relevant to fix. Second commit just contains prettier-formatting applied to changed files.~ EDIT: No longer relevant, as fix changed completely and formatting changes are omitted from PR