### PR TITLE
feat!: rename projectKeyToPublicId to keyToPublicId

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Key management and encryption / decryption functions for Mapeo.
   - [Parameters](#parameters-10)
 - [`verify(message, signature, publicKey)`](#verifymessage-signature-publickey)
   - [Parameters](#parameters-11)
-- [`projectKeyToPublicId(projectKey)`](#projectkeytopublicidprojectkey)
+- [`keyToPublicId(key)`](#keytopublicidkey)
   - [Parameters](#parameters-12)
 - [Type `JoinRequest`](#type-joinrequest)
 
@@ -258,15 +258,15 @@ Verify that `signature` is a valid signature of `message` created by the owner o
 
 Returns `boolean` indicating if valid or not.
 
-### `projectKeyToPublicId(projectKey)`
+### `keyToPublicId(key)`
 
-Get a project public ID from the project key. The project public ID is a hash of the project key and safe to share publicly. The hash is encoded as [z-base-32](http://philzimmermann.com/docs/human-oriented-base-32-encoding.txt)
+Get a public ID from a key. The public ID is a hash of the key and safe to share publicly. The hash is encoded as [z-base-32](http://philzimmermann.com/docs/human-oriented-base-32-encoding.txt)
 
 #### Parameters
 
-- `projectKey: Buffer`
+- `key: Buffer`
 
-Returns `string` z-base-32 encoded hash of the project key
+Returns `string` z-base-32 encoded hash of the key
 
 ### Type `JoinRequest`
 

--- a/index.js
+++ b/index.js
@@ -1,8 +1,12 @@
 // @ts-check
-const { sign, verifySignature, projectKeyToPublicId } = require('./utils.js')
+const {
+  sign,
+  verifySignature,
+  keyToPublicId,
+} = require('./utils.js')
 
 exports.KeyManager = require('./key-manager')
 exports.invites = require('./project-invites')
 exports.sign = sign
 exports.verifySignature = verifySignature
-exports.projectKeyToPublicId = projectKeyToPublicId
+exports.keyToPublicId = keyToPublicId

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -5,7 +5,7 @@ const {
   KeyManager,
   sign,
   verifySignature,
-  projectKeyToPublicId
+  keyToPublicId
 } = require('../')
 const z32 = require('z32')
 
@@ -22,18 +22,18 @@ test('sign & verify', function (t) {
   t.end()
 })
 
-test('project public ID', function (t) {
-  const projectKey = createHash('sha256').update('test key').digest()
-  const projectPublicId = projectKeyToPublicId(projectKey)
+test('key to public ID', function (t) {
+  const key = createHash('sha256').update('test key').digest()
+  const publicId = keyToPublicId(key)
   t.equal(
-    projectPublicId,
+    publicId,
     'zmpu4uwx5eze9jmug6ycgwnirsy4rzfym3c4987gpjsdxzmomi4o',
     'checks for consistency - a change is a breaking change'
   )
-  t.equal(projectKeyToPublicId(projectKey), projectPublicId, 'deterministic')
+  t.equal(keyToPublicId(key), publicId, 'deterministic')
   t.notSame(
-    z32.decode(projectPublicId),
-    projectKey,
+    z32.decode(publicId),
+    key,
     "didn't do something dumb and encode without hashing"
   )
   t.end()

--- a/utils.js
+++ b/utils.js
@@ -29,15 +29,15 @@ exports.verifySignature = function (message, signature, publicKey) {
 }
 
 /**
- * Get a project public ID from the project key. The project public ID is a hash
- * of the project key and safe to share publicly. The hash is encoded as
+ * Get a public ID from a key. The public ID is a hash
+ * of the key and safe to share publicly. The hash is encoded as
  * [z-base-32](http://philzimmermann.com/docs/human-oriented-base-32-encoding.txt)
  *
- * @param {Buffer} projectKey
- * @returns {string} z-base-32 encoded hash of the project key
+ * @param {Buffer} key
+ * @returns {string} z-base-32 encoded hash of the key
  */
-exports.projectKeyToPublicId = function (projectKey) {
+exports.keyToPublicId = function (key) {
   const digest = Buffer.allocUnsafe(32)
-  sodium.crypto_generichash(digest, MAPEO, projectKey)
+  sodium.crypto_generichash(digest, MAPEO, key)
   return z32.encode(digest)
 }


### PR DESCRIPTION
just a naming change as it's useful for generic key -> public id purposes and not tied to projects whatsoever