### PR TITLE
feat: keyToInviteId

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const {
   sign,
   verifySignature,
   keyToPublicId,
+  keyToInviteId,
 } = require('./utils.js')
 
 exports.KeyManager = require('./key-manager')
@@ -10,3 +11,4 @@ exports.invites = require('./project-invites')
 exports.sign = sign
 exports.verifySignature = verifySignature
 exports.keyToPublicId = keyToPublicId
+exports.keyToInviteId = keyToInviteId

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -5,7 +5,8 @@ const {
   KeyManager,
   sign,
   verifySignature,
-  keyToPublicId
+  keyToPublicId,
+  keyToInviteId,
 } = require('../')
 const z32 = require('z32')
 
@@ -34,6 +35,23 @@ test('key to public ID', function (t) {
   t.notSame(
     z32.decode(publicId),
     key,
+    "didn't do something dumb and encode without hashing"
+  )
+  t.end()
+})
+
+test('key to invite ID', (t) => {
+  const key = createHash('sha256').update('test key').digest()
+  const inviteId = keyToInviteId(key)
+  t.same(
+    inviteId,
+    Buffer.from('eQro+t0dzx2AFf3h9Bh5A94i0YdR19xJkq+NGny+IS0=', 'base64'),
+    'checks for consistency - a change is a breaking change'
+  )
+  t.same(keyToInviteId(key), inviteId, 'deterministic')
+  t.notSame(
+    key,
+    inviteId,
     "didn't do something dumb and encode without hashing"
   )
   t.end()

--- a/utils.js
+++ b/utils.js
@@ -3,6 +3,7 @@ const sodium = require('sodium-universal')
 const z32 = require('z32')
 
 const MAPEO = Buffer.from('mapeo')
+const PROJECT_INVITE_ID_SALT = Buffer.from('mapeo project invite id', 'ascii')
 
 /**
  * Sign message using secretKey
@@ -40,4 +41,15 @@ exports.keyToPublicId = function (key) {
   const digest = Buffer.allocUnsafe(32)
   sodium.crypto_generichash(digest, MAPEO, key)
   return z32.encode(digest)
+}
+
+/**
+ * Generate an invite ID from a project key
+ * @param {Readonly<Buffer>} key
+ * @returns {Buffer}
+ */
+exports.keyToInviteId = function (key) {
+  const digest = Buffer.allocUnsafe(32)
+  sodium.crypto_generichash(digest, PROJECT_INVITE_ID_SALT, key)
+  return digest
 }


### PR DESCRIPTION
Similar to `keyToPublicId`, this adds a `keyToInviteId` for deriving an invite ID.

This was originally added in `@mapeo/core` but should live here instead. See <https://github.com/digidem/mapeo-core-next/pull/571>.