### PR TITLE
chore: use upstream types for `compact-encoding`

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "@digidem/types": "^2.0.0",
+    "@types/compact-encoding": "^2.15.0",
     "@types/crc": "^3.4.0",
     "@types/lodash": "^4.14.178",
     "@types/node": "^18.17.5",

--- a/types/compact-encoding.d.ts
+++ b/types/compact-encoding.d.ts
@@ -1,4 +1,0 @@
-declare module 'compact-encoding' {
-  const cenc: any
-  export = cenc
-}


### PR DESCRIPTION
This is a types-only change.

[`@types/compact-encoding`][0] was recently published. Let's use that instead of our "empty" type.

[0]: https://www.npmjs.com/package/@types/compact-encoding